### PR TITLE
Hide all tags, not just certain tags.

### DIFF
--- a/src/css/common.css
+++ b/src/css/common.css
@@ -7,7 +7,7 @@ body {
    font-family: Helvetica, Arial, sans-serif;
 }
 
-span.tag span.slide,span.fold {
+span.tag {
    display: none;
 }
 


### PR DESCRIPTION
I'm not sure if there's a specific reason to hide only the slide and fold tags. I've run into situations where I want to use other tags for styling, since they show up in the HTML as classes. So it makes more sense to me to just hide them all.
